### PR TITLE
docs: automate contributor avatars

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,97 @@
+name: Update contributor avatars
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-contributor-avatars
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: github.repository == 'agent-network-protocol/AgentNetworkProtocol'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update README contributor blocks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const startMarker = '<!-- contributors:start -->';
+            const endMarker = '<!-- contributors:end -->';
+
+            let response;
+            for (let attempt = 0; attempt < 6; attempt += 1) {
+              response = await github.request(
+                'GET /repos/{owner}/{repo}/stats/contributors',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                },
+              );
+              if (response.status === 200) break;
+              await new Promise((resolve) => setTimeout(resolve, 10000));
+            }
+
+            if (response.status !== 200 || !Array.isArray(response.data)) {
+              core.setFailed(`Contributor statistics unavailable: HTTP ${response.status}`);
+              return;
+            }
+
+            const contributors = response.data
+              .filter(({ author }) => author && author.type !== 'Bot')
+              .sort((left, right) => {
+                if (right.total !== left.total) return right.total - left.total;
+                return left.author.login
+                  .toLowerCase()
+                  .localeCompare(right.author.login.toLowerCase());
+              });
+
+            const avatars = contributors
+              .map(({ author }) =>
+                `<a href="${author.html_url}"><img src="${author.avatar_url}" width="64" height="64" alt="@${author.login}" /></a>`,
+              )
+              .join('\n');
+
+            for (const file of ['README.md', 'README.cn.md']) {
+              const source = fs.readFileSync(file, 'utf8');
+              const start = source.indexOf(startMarker);
+              const end = source.indexOf(endMarker);
+              if (start < 0 || end < 0 || end <= start) {
+                core.setFailed(`Contributor markers are invalid in ${file}`);
+                return;
+              }
+
+              const updated =
+                source.slice(0, start + startMarker.length) +
+                `\n${avatars}\n` +
+                source.slice(end);
+              fs.writeFileSync(file, updated);
+            }
+
+            core.info(`Rendered ${contributors.length} contributor avatars`);
+
+      - name: Commit updated contributor avatars
+        shell: bash
+        run: |
+          if git diff --quiet -- README.md README.cn.md; then
+            echo "Contributor avatars are already up to date"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README.cn.md
+          git commit -m "docs: update contributor avatars"
+          git push

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -31,26 +31,56 @@ jobs:
             const startMarker = '<!-- contributors:start -->';
             const endMarker = '<!-- contributors:end -->';
 
-            let response;
+            const contributorsById = new Map();
+            for (let page = 1; ; page += 1) {
+              const pageResponse = await github.request(
+                'GET /repos/{owner}/{repo}/contributors',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 100,
+                  page,
+                },
+              );
+              if (pageResponse.status !== 200 || !Array.isArray(pageResponse.data)) {
+                core.setFailed(`Contributor page ${page} unavailable: HTTP ${pageResponse.status}`);
+                return;
+              }
+
+              for (const contributor of pageResponse.data) {
+                if (!contributor.login || contributor.type === 'Bot') continue;
+                contributorsById.set(contributor.id, {
+                  author: contributor,
+                  total: contributor.contributions ?? 0,
+                });
+              }
+              if (pageResponse.data.length < 100) break;
+            }
+
+            let statsResponse;
             for (let attempt = 0; attempt < 6; attempt += 1) {
-              response = await github.request(
+              statsResponse = await github.request(
                 'GET /repos/{owner}/{repo}/stats/contributors',
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                 },
               );
-              if (response.status === 200) break;
+              if (statsResponse.status === 200) break;
               await new Promise((resolve) => setTimeout(resolve, 10000));
             }
 
-            if (response.status !== 200 || !Array.isArray(response.data)) {
-              core.setFailed(`Contributor statistics unavailable: HTTP ${response.status}`);
+            if (statsResponse.status !== 200 || !Array.isArray(statsResponse.data)) {
+              core.setFailed(`Contributor statistics unavailable: HTTP ${statsResponse.status}`);
               return;
             }
 
-            const contributors = response.data
-              .filter(({ author }) => author && author.type !== 'Bot')
+            for (const contributor of statsResponse.data) {
+              if (!contributor.author || contributor.author.type === 'Bot') continue;
+              contributorsById.set(contributor.author.id, contributor);
+            }
+
+            const contributors = Array.from(contributorsById.values())
               .sort((left, right) => {
                 if (right.total !== left.total) return right.total - left.total;
                 return left.author.login

--- a/README.cn.md
+++ b/README.cn.md
@@ -149,7 +149,29 @@ AgentConnect 重点提供 `did:wba`、身份认证、智能体描述、协议协
 
 感谢所有为 Agent Network Protocol 项目做出贡献的人。
 
-- [贡献者名单](CONTRIBUTORS.cn.md)
+<!-- contributors:start -->
+<a href="https://github.com/chgaowei"><img src="https://avatars.githubusercontent.com/u/1315207?v=4" width="64" height="64" alt="@chgaowei" /></a>
+<a href="https://github.com/yagi2018"><img src="https://avatars.githubusercontent.com/u/45328391?v=4" width="64" height="64" alt="@yagi2018" /></a>
+<a href="https://github.com/Julian-Zhu-STD"><img src="https://avatars.githubusercontent.com/u/238634316?v=4" width="64" height="64" alt="@Julian-Zhu-STD" /></a>
+<a href="https://github.com/amdoi7"><img src="https://avatars.githubusercontent.com/u/91404105?v=4" width="64" height="64" alt="@amdoi7" /></a>
+<a href="https://github.com/claude"><img src="https://avatars.githubusercontent.com/u/81847?v=4" width="64" height="64" alt="@claude" /></a>
+<a href="https://github.com/han188"><img src="https://avatars.githubusercontent.com/u/15783771?v=4" width="64" height="64" alt="@han188" /></a>
+<a href="https://github.com/khyao78"><img src="https://avatars.githubusercontent.com/u/59645954?v=4" width="64" height="64" alt="@khyao78" /></a>
+<a href="https://github.com/AlfredZuo"><img src="https://avatars.githubusercontent.com/u/22234543?v=4" width="64" height="64" alt="@AlfredZuo" /></a>
+<a href="https://github.com/dzpzp"><img src="https://avatars.githubusercontent.com/u/116531432?v=4" width="64" height="64" alt="@dzpzp" /></a>
+<a href="https://github.com/yumh1"><img src="https://avatars.githubusercontent.com/u/238633659?v=4" width="64" height="64" alt="@yumh1" /></a>
+<a href="https://github.com/Aas-ee"><img src="https://avatars.githubusercontent.com/u/81606643?v=4" width="64" height="64" alt="@Aas-ee" /></a>
+<a href="https://github.com/cocolin2016"><img src="https://avatars.githubusercontent.com/u/70193777?v=4" width="64" height="64" alt="@cocolin2016" /></a>
+<a href="https://github.com/dreamsea656"><img src="https://avatars.githubusercontent.com/u/11325618?v=4" width="64" height="64" alt="@dreamsea656" /></a>
+<a href="https://github.com/kylezhang"><img src="https://avatars.githubusercontent.com/u/3679798?v=4" width="64" height="64" alt="@kylezhang" /></a>
+<a href="https://github.com/Pentiumtime"><img src="https://avatars.githubusercontent.com/u/129046354?v=4" width="64" height="64" alt="@Pentiumtime" /></a>
+<a href="https://github.com/seanzhang9999"><img src="https://avatars.githubusercontent.com/u/25133739?v=4" width="64" height="64" alt="@seanzhang9999" /></a>
+<a href="https://github.com/SeaOceanO"><img src="https://avatars.githubusercontent.com/u/287401010?v=4" width="64" height="64" alt="@SeaOceanO" /></a>
+<a href="https://github.com/SunZhao2468"><img src="https://avatars.githubusercontent.com/u/238628622?v=4" width="64" height="64" alt="@SunZhao2468" /></a>
+<a href="https://github.com/xfq"><img src="https://avatars.githubusercontent.com/u/2863444?v=4" width="64" height="64" alt="@xfq" /></a>
+<!-- contributors:end -->
+
+- [查看完整贡献者名单](CONTRIBUTORS.cn.md)
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,29 @@ We welcome contributions in any form. Please refer to [CONTRIBUTING.md](CONTRIBU
 
 We extend our sincere gratitude to all contributors for their outstanding work and dedication to the Agent Network Protocol project.
 
-- [Contributors](CONTRIBUTORS.md)
+<!-- contributors:start -->
+<a href="https://github.com/chgaowei"><img src="https://avatars.githubusercontent.com/u/1315207?v=4" width="64" height="64" alt="@chgaowei" /></a>
+<a href="https://github.com/yagi2018"><img src="https://avatars.githubusercontent.com/u/45328391?v=4" width="64" height="64" alt="@yagi2018" /></a>
+<a href="https://github.com/Julian-Zhu-STD"><img src="https://avatars.githubusercontent.com/u/238634316?v=4" width="64" height="64" alt="@Julian-Zhu-STD" /></a>
+<a href="https://github.com/amdoi7"><img src="https://avatars.githubusercontent.com/u/91404105?v=4" width="64" height="64" alt="@amdoi7" /></a>
+<a href="https://github.com/claude"><img src="https://avatars.githubusercontent.com/u/81847?v=4" width="64" height="64" alt="@claude" /></a>
+<a href="https://github.com/han188"><img src="https://avatars.githubusercontent.com/u/15783771?v=4" width="64" height="64" alt="@han188" /></a>
+<a href="https://github.com/khyao78"><img src="https://avatars.githubusercontent.com/u/59645954?v=4" width="64" height="64" alt="@khyao78" /></a>
+<a href="https://github.com/AlfredZuo"><img src="https://avatars.githubusercontent.com/u/22234543?v=4" width="64" height="64" alt="@AlfredZuo" /></a>
+<a href="https://github.com/dzpzp"><img src="https://avatars.githubusercontent.com/u/116531432?v=4" width="64" height="64" alt="@dzpzp" /></a>
+<a href="https://github.com/yumh1"><img src="https://avatars.githubusercontent.com/u/238633659?v=4" width="64" height="64" alt="@yumh1" /></a>
+<a href="https://github.com/Aas-ee"><img src="https://avatars.githubusercontent.com/u/81606643?v=4" width="64" height="64" alt="@Aas-ee" /></a>
+<a href="https://github.com/cocolin2016"><img src="https://avatars.githubusercontent.com/u/70193777?v=4" width="64" height="64" alt="@cocolin2016" /></a>
+<a href="https://github.com/dreamsea656"><img src="https://avatars.githubusercontent.com/u/11325618?v=4" width="64" height="64" alt="@dreamsea656" /></a>
+<a href="https://github.com/kylezhang"><img src="https://avatars.githubusercontent.com/u/3679798?v=4" width="64" height="64" alt="@kylezhang" /></a>
+<a href="https://github.com/Pentiumtime"><img src="https://avatars.githubusercontent.com/u/129046354?v=4" width="64" height="64" alt="@Pentiumtime" /></a>
+<a href="https://github.com/seanzhang9999"><img src="https://avatars.githubusercontent.com/u/25133739?v=4" width="64" height="64" alt="@seanzhang9999" /></a>
+<a href="https://github.com/SeaOceanO"><img src="https://avatars.githubusercontent.com/u/287401010?v=4" width="64" height="64" alt="@SeaOceanO" /></a>
+<a href="https://github.com/SunZhao2468"><img src="https://avatars.githubusercontent.com/u/238628622?v=4" width="64" height="64" alt="@SunZhao2468" /></a>
+<a href="https://github.com/xfq"><img src="https://avatars.githubusercontent.com/u/2863444?v=4" width="64" height="64" alt="@xfq" /></a>
+<!-- contributors:end -->
+
+- [View the full contributors list](CONTRIBUTORS.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

- display all 19 contributors as clickable avatars in the English and Chinese READMEs
- source the avatar list from GitHub contributor statistics so accounts omitted by contrib.rocks are included
- refresh contributor blocks after pushes to main and every six hours
- filter automation accounts from the generated avatar list

## Validation

- confirmed both README files contain the same 19 contributors returned by GitHub statistics
- confirmed GitHub Markdown renders 19 avatars in each README
- validated the workflow JavaScript syntax
- ran git diff --check

## Operational note

The repository must allow GitHub Actions to use contents: write so the workflow can commit refreshed avatar blocks to main.