### PR TITLE
docs: explain Agent Description extended fields

### DIFF
--- a/07-anp-agent-description-protocol-specification.md
+++ b/07-anp-agent-description-protocol-specification.md
@@ -579,10 +579,6 @@ The following is an example of an interface description document conforming to t
 To be supplemented
 
 
-### JSON-LD Format
-
-
-
 ### Security Mechanism
 
 The Agent Description Protocol currently uses the did:wba method as its security mechanism. The did:wba method is a web-based Decentralized Identifier (DID) specification designed to meet the needs of cross-platform identity authentication and agent communication.

--- a/07-anp-agent-description-protocol-specification.md
+++ b/07-anp-agent-description-protocol-specification.md
@@ -661,4 +661,4 @@ A similar approach can be used for interfaces. For example, for a product purcha
 
 ## Copyright Notice  
 Copyright (c) 2024 GaoWei Chang  
-This document is released under the [MIT License](./LICENSE). You are free to use and modify it, but you must retain this copyright notice.
+This document is released under the [Apache License 2.0](./LICENSE). You are free to use and modify it under the terms of that license, but you must retain this copyright notice.

--- a/07-anp-agent-description-protocol-specification.md
+++ b/07-anp-agent-description-protocol-specification.md
@@ -64,6 +64,10 @@ Benefiting from improved AI capabilities, agent description documents can be ent
 
 For agent description format, we recommend using JSON format. We have defined an ANP-compliant agent description document format based on standard JSON.
 
+For practical guidance on the ANP-specific and domain-specific fields used by
+the examples in this repository, see
+[Extended Fields in Agent Description Documents](docs/agent-description-extended-fields-guide.md).
+
 #### Agent Description Document
 
 The following is an example of an agent description document:

--- a/docs/agent-description-extended-fields-guide.md
+++ b/docs/agent-description-extended-fields-guide.md
@@ -1,0 +1,226 @@
+# Extended Fields in Agent Description Documents
+
+This guide explains how extended fields are used in the Agent Description
+examples in this repository. It supplements the
+[Agent Description Protocol specification](../07-anp-agent-description-protocol-specification.md);
+it does not add new protocol requirements.
+
+The examples combine three kinds of terms:
+
+- fields defined by the Agent Description Protocol;
+- terms from an external vocabulary, such as Schema.org; and
+- ANP-specific terms identified by the `ad` prefix.
+
+Keeping these groups separate makes a description easier to interpret and
+reduces the chance that two fields with the same short name are treated as the
+same property.
+
+## Declaring Vocabularies
+
+The hotel and coffee shop examples use a JSON-LD context:
+
+```json
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "did": "https://w3id.org/did#",
+    "ad": "https://service.agent-network-protocol.com/ad#"
+  }
+}
+```
+
+`@vocab` supplies the vocabulary for unprefixed terms such as `name`,
+`address`, and `telephone`. The `ad` prefix identifies fields and types that
+belong to the ANP description vocabulary. The `did` prefix is available for
+DID-related terms.
+
+Use a prefix for a field that is not defined by the default vocabulary. Do not
+reuse an existing vocabulary term with a different meaning.
+
+## Extensions Used by the Examples
+
+### `ad:domainEntity`
+
+| Property | Value |
+| --- | --- |
+| Expected type | object |
+| Required | No |
+| Used in | Hotel and coffee shop Agent Descriptions |
+
+`ad:domainEntity` associates an agent with the real-world or digital entity it
+represents. Its contents depend on the domain. The hotel example uses a
+Schema.org `Hotel`; the coffee shop example uses `CafeOrCoffeeShop`.
+
+```json
+{
+  "ad:domainEntity": {
+    "@type": "Hotel",
+    "name": "Example Hotel",
+    "telephone": "+1-555-0100"
+  }
+}
+```
+
+Prefer an established type and properties from the declared vocabulary for the
+object's contents. Add a separate prefixed term only when the selected
+vocabulary does not express the required information.
+
+### `ad:products`
+
+| Property | Value |
+| --- | --- |
+| Expected type | array |
+| Required | No |
+| Used in | Coffee shop Agent Description |
+
+`ad:products` lists products exposed by the domain entity. Each entry can
+contain a short inline description and an `@id` that points to a more detailed
+Product document.
+
+```json
+{
+  "ad:products": [
+    {
+      "@type": "Product",
+      "name": "House Coffee",
+      "description": "The shop's standard brewed coffee.",
+      "@id": "https://example.com/products/house-coffee.json"
+    }
+  ]
+}
+```
+
+Use a stable, dereferenceable `@id` when product details are stored in a
+separate document. Avoid copying a complete product record into the Agent
+Description when a link is sufficient.
+
+### `ad:interfaces`
+
+| Property | Value |
+| --- | --- |
+| Expected type | array |
+| Required | No |
+| Used in | Hotel and coffee shop Agent Descriptions |
+
+`ad:interfaces` lists the interfaces through which another agent can interact
+with the described agent. The examples use ANP-specific interface types with
+`protocol`, `url`, and `description` fields.
+
+```json
+{
+  "ad:interfaces": [
+    {
+      "@type": "ad:NaturalLanguageInterface",
+      "protocol": "YAML",
+      "url": "https://example.com/api/nl-interface.yaml",
+      "description": "Natural-language inquiries and responses."
+    }
+  ]
+}
+```
+
+The current examples contain the following interface types:
+
+| Type | Purpose |
+| --- | --- |
+| `ad:NaturalLanguageInterface` | Conversational requests expressed in natural language |
+| `ad:SearchInterface` | Structured search and filtering |
+| `ad:BookingInterface` | Reservations or bookings |
+| `ad:PurchaseInterface` | Product or service purchases |
+
+An interface entry describes how to find the interface contract; it is not the
+contract itself. Place endpoint paths, request parameters, and response schemas
+in the linked interface document.
+
+For an operation that needs direct user approval, the Agent Description
+specification defines the boolean `humanAuthorization` field. Set it on the
+relevant interface rather than assuming that authentication alone grants
+permission to perform the operation.
+
+### `ad:securityDefinitions` and `ad:security`
+
+| Property | Expected type | Required by the current specification |
+| --- | --- | --- |
+| `ad:securityDefinitions` | object | Yes |
+| `ad:security` | string | Yes |
+
+The JSON-LD examples prefix the security fields with `ad`. The first field
+defines the available security schemes; the second selects one of those
+definitions by name.
+
+```json
+{
+  "ad:securityDefinitions": {
+    "didwba_sc": {
+      "scheme": "didwba",
+      "in": "header",
+      "name": "Authorization"
+    }
+  },
+  "ad:security": "didwba_sc"
+}
+```
+
+These fields describe the authentication mechanism. They must not contain
+private keys, bearer tokens, passwords, or other credentials.
+
+### Product customization
+
+The coffee product examples use `customizationOptions` with the ANP-specific
+type `ad:CustomizationOptions`. Its `options` array contains `PropertyValue`
+objects that describe the choices available to a buyer.
+
+```json
+{
+  "customizationOptions": {
+    "@type": "ad:CustomizationOptions",
+    "options": [
+      {
+        "@type": "PropertyValue",
+        "name": "Size",
+        "isRequired": true,
+        "value": ["Small", "Medium", "Large"]
+      }
+    ]
+  }
+}
+```
+
+In these examples, `isRequired` means that the buyer must select a value for
+that option. It does not make `customizationOptions` a required field in every
+Product document.
+
+When an interface accepts these selections, its request schema should use the
+same option names and permitted values as the Product document.
+
+## Adding a Domain-Specific Field
+
+Before adding a field:
+
+1. Check whether the Agent Description specification already defines it.
+2. Check whether the declared external vocabulary contains a term with the
+   intended meaning.
+3. If neither does, declare or reuse a suitable prefix and use it consistently.
+4. State the expected JSON type and whether the field is optional or required
+   within the extension.
+5. Add a small example and update the interface contract if the field is used
+   as an input or output.
+
+Extensions should remain optional unless a separate specification makes them
+mandatory. A consumer that does not understand an optional extension should
+still be able to read the agent's identity, description, security settings, and
+interface links.
+
+## Related Examples
+
+- [Hotel Agent Description](../examples/adp/hotel/examples/ad.json)
+- [Hotel room description](../examples/adp/hotel/examples/hotel_room.json)
+- [Coffee shop Agent Description](../examples/adp/lkcoffe/ad.json)
+- [Coffee purchase interface](../examples/adp/lkcoffe/api/purchase-interface.yaml)
+
+## Copyright Notice
+
+Copyright (c) 2024 GaoWei Chang
+
+This file is released under the [MIT License](../LICENSE). You are free to use
+and modify it, but you must retain this copyright notice.

--- a/docs/agent-description-extended-fields-guide.md
+++ b/docs/agent-description-extended-fields-guide.md
@@ -230,5 +230,6 @@ links, and interfaces.
 
 Copyright (c) 2024 GaoWei Chang
 
-This file is released under the [MIT License](../LICENSE). You are free to use
-and modify it, but you must retain this copyright notice.
+This file is released under the [Apache License 2.0](../LICENSE). You are free
+to use and modify it under the terms of that license, but you must retain this
+copyright notice.

--- a/docs/agent-description-extended-fields-guide.md
+++ b/docs/agent-description-extended-fields-guide.md
@@ -1,182 +1,167 @@
 # Extended Fields in Agent Description Documents
 
-This guide explains how extended fields are used in the Agent Description
+This guide explains the optional fields used by the hotel and coffee-shop
 examples in this repository. It supplements the
-[Agent Description Protocol specification](../07-anp-agent-description-protocol-specification.md);
-it does not add new protocol requirements.
+[Agent Description Protocol specification](../07-anp-agent-description-protocol-specification.md)
+and does not add new protocol requirements.
 
-The examples combine three kinds of terms:
+ANP-07 v1.1 uses standard JSON. Agent Description and Product documents use
+ordinary field names such as `type` and `url`. The examples in this guide
+follow that format.
 
-- fields defined by the Agent Description Protocol;
-- terms from an external vocabulary, such as Schema.org; and
-- ANP-specific terms identified by the `ad` prefix.
+## Start with the ANP-07 Fields
 
-Keeping these groups separate makes a description easier to interpret and
-reduces the chance that two fields with the same short name are treated as the
-same property.
+An Agent Description must contain the fields that ANP-07 marks as required.
+Optional domain fields can then be added alongside them.
 
-## Declaring Vocabularies
+| Field | Type | Status | Purpose |
+| --- | --- | --- | --- |
+| `protocolType` | string | Required | Fixed value `ANP` |
+| `protocolVersion` | string | Required | ANP protocol version used by the document |
+| `type` | string | Required | `AgentDescription` for an Agent Description document |
+| `url` | string | Optional | Address of the Agent Description document |
+| `name` | string | Required | Human-readable agent name |
+| `did` | string | Optional | DID used to identify the agent |
+| `owner` | object | Optional | Person or organization responsible for the agent |
+| `description` | string | Optional | Summary of the agent's purpose and capabilities |
+| `created` | string | Optional | Creation time in ISO 8601 format |
+| `securityDefinitions` | object | Required | Available authentication schemes |
+| `security` | string | Required | Active entry from `securityDefinitions` |
+| `Infomations` | array | Optional | Links to products, services, or other information resources |
+| `interfaces` | array | Optional | Interfaces exposed by the agent |
+| `proof` | object | Optional | Document integrity proof |
 
-The hotel and coffee shop examples use a JSON-LD context:
+`Infomations` is the field name used by the current ANP-07 specification. The
+examples retain that spelling for compatibility with the specification.
 
-```json
-{
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "did": "https://w3id.org/did#",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  }
-}
-```
-
-`@vocab` supplies the vocabulary for unprefixed terms such as `name`,
-`address`, and `telephone`. The `ad` prefix identifies fields and types that
-belong to the ANP description vocabulary. The `did` prefix is available for
-DID-related terms.
-
-Use a prefix for a field that is not defined by the default vocabulary. Do not
-reuse an existing vocabulary term with a different meaning.
-
-## Extensions Used by the Examples
-
-### `ad:domainEntity`
-
-| Property | Value |
-| --- | --- |
-| Expected type | object |
-| Required | No |
-| Used in | Hotel and coffee shop Agent Descriptions |
-
-`ad:domainEntity` associates an agent with the real-world or digital entity it
-represents. Its contents depend on the domain. The hotel example uses a
-Schema.org `Hotel`; the coffee shop example uses `CafeOrCoffeeShop`.
+A minimal description with one domain extension looks like this:
 
 ```json
 {
-  "ad:domainEntity": {
-    "@type": "Hotel",
-    "name": "Example Hotel",
-    "telephone": "+1-555-0100"
-  }
-}
-```
-
-Prefer an established type and properties from the declared vocabulary for the
-object's contents. Add a separate prefixed term only when the selected
-vocabulary does not express the required information.
-
-### `ad:products`
-
-| Property | Value |
-| --- | --- |
-| Expected type | array |
-| Required | No |
-| Used in | Coffee shop Agent Description |
-
-`ad:products` lists products exposed by the domain entity. Each entry can
-contain a short inline description and an `@id` that points to a more detailed
-Product document.
-
-```json
-{
-  "ad:products": [
-    {
-      "@type": "Product",
-      "name": "House Coffee",
-      "description": "The shop's standard brewed coffee.",
-      "@id": "https://example.com/products/house-coffee.json"
-    }
-  ]
-}
-```
-
-Use a stable, dereferenceable `@id` when product details are stored in a
-separate document. Avoid copying a complete product record into the Agent
-Description when a link is sufficient.
-
-### `ad:interfaces`
-
-| Property | Value |
-| --- | --- |
-| Expected type | array |
-| Required | No |
-| Used in | Hotel and coffee shop Agent Descriptions |
-
-`ad:interfaces` lists the interfaces through which another agent can interact
-with the described agent. The examples use ANP-specific interface types with
-`protocol`, `url`, and `description` fields.
-
-```json
-{
-  "ad:interfaces": [
-    {
-      "@type": "ad:NaturalLanguageInterface",
-      "protocol": "YAML",
-      "url": "https://example.com/api/nl-interface.yaml",
-      "description": "Natural-language inquiries and responses."
-    }
-  ]
-}
-```
-
-The current examples contain the following interface types:
-
-| Type | Purpose |
-| --- | --- |
-| `ad:NaturalLanguageInterface` | Conversational requests expressed in natural language |
-| `ad:SearchInterface` | Structured search and filtering |
-| `ad:BookingInterface` | Reservations or bookings |
-| `ad:PurchaseInterface` | Product or service purchases |
-
-An interface entry describes how to find the interface contract; it is not the
-contract itself. Place endpoint paths, request parameters, and response schemas
-in the linked interface document.
-
-For an operation that needs direct user approval, the Agent Description
-specification defines the boolean `humanAuthorization` field. Set it on the
-relevant interface rather than assuming that authentication alone grants
-permission to perform the operation.
-
-### `ad:securityDefinitions` and `ad:security`
-
-| Property | Expected type | Required by the current specification |
-| --- | --- | --- |
-| `ad:securityDefinitions` | object | Yes |
-| `ad:security` | string | Yes |
-
-The JSON-LD examples prefix the security fields with `ad`. The first field
-defines the available security schemes; the second selects one of those
-definitions by name.
-
-```json
-{
-  "ad:securityDefinitions": {
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "AgentDescription",
+  "url": "https://example.com/agents/hotel/ad.json",
+  "name": "Hotel Booking Agent",
+  "did": "did:wba:example.com:agents:hotel",
+  "securityDefinitions": {
     "didwba_sc": {
       "scheme": "didwba",
       "in": "header",
       "name": "Authorization"
     }
   },
-  "ad:security": "didwba_sc"
+  "security": "didwba_sc",
+  "domainEntity": {
+    "type": "Hotel",
+    "name": "Example Hotel",
+    "telephone": "+1-555-0100"
+  }
 }
 ```
 
-These fields describe the authentication mechanism. They must not contain
-private keys, bearer tokens, passwords, or other credentials.
+## Linking Information Resources
 
-### Product customization
+Use `Infomations` for resources that have their own documents. A short entry
+states what the resource contains and where it can be retrieved.
 
-The coffee product examples use `customizationOptions` with the ANP-specific
-type `ad:CustomizationOptions`. Its `options` array contains `PropertyValue`
-objects that describe the choices available to a buyer.
+```json
+{
+  "Infomations": [
+    {
+      "type": "Product",
+      "description": "Room details, rates, and booking conditions.",
+      "url": "https://example.com/products/deluxe-room.json"
+    }
+  ]
+}
+```
+
+The linked Product document uses the standard fields defined in the Product
+Description section of ANP-07. Keep detailed pricing, images, and product
+properties in that document rather than copying them into the Agent
+Description.
+
+## Describing Interfaces
+
+The examples use the two interface types defined by ANP-07:
+
+- `NaturalLanguageInterface` for conversational requests;
+- `StructuredInterface` for operations described by a machine-readable
+  contract.
+
+```json
+{
+  "interfaces": [
+    {
+      "type": "StructuredInterface",
+      "protocol": "YAML",
+      "version": "1.0",
+      "humanAuthorization": true,
+      "url": "https://example.com/api/booking-interface.yaml",
+      "description": "Hotel room booking and reservation management."
+    }
+  ]
+}
+```
+
+Endpoint paths, request parameters, and response schemas belong in the linked
+interface contract. Set `humanAuthorization` to `true` when the operation
+requires direct user approval, such as confirming a booking or purchase.
+
+## Extensions Used by the Examples
+
+### `domainEntity`
+
+| Property | Value |
+| --- | --- |
+| Expected type | object |
+| Required | No |
+| Used in | Hotel and coffee-shop Agent Descriptions |
+
+`domainEntity` describes the organization, place, or other entity represented
+by the agent. The value is an ordinary JSON object. Its `type` identifies the
+kind of entity, while the remaining fields describe that entity.
+
+The hotel example includes address, location, rating, images, amenities, and
+services. The coffee-shop example includes address, opening hours, telephone,
+and location. These properties are optional and should be selected according
+to the domain.
+
+```json
+{
+  "domainEntity": {
+    "type": "CafeOrCoffeeShop",
+    "name": "Example Coffee Shop",
+    "openingHours": "Mo-Su 07:00-22:00",
+    "address": {
+      "type": "PostalAddress",
+      "addressLocality": "Example City",
+      "addressCountry": "CN"
+    }
+  }
+}
+```
+
+### `customizationOptions`
+
+| Property | Value |
+| --- | --- |
+| Expected type | object |
+| Required | No |
+| Used in | Coffee Product documents |
+
+`customizationOptions` lists choices that can be made when ordering a product.
+Each item in `options` has a name, a list of accepted values, and an optional
+`isRequired` flag.
 
 ```json
 {
   "customizationOptions": {
-    "@type": "ad:CustomizationOptions",
+    "type": "CustomizationOptions",
     "options": [
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "Size",
         "isRequired": true,
         "value": ["Small", "Medium", "Large"]
@@ -186,36 +171,59 @@ objects that describe the choices available to a buyer.
 }
 ```
 
-In these examples, `isRequired` means that the buyer must select a value for
-that option. It does not make `customizationOptions` a required field in every
-Product document.
+`isRequired` applies to the individual choice. It does not make
+`customizationOptions` mandatory for every Product document. A purchase
+interface that accepts these choices should use the same option names and
+permitted values.
 
-When an interface accepts these selections, its request schema should use the
-same option names and permitted values as the Product document.
+### Hotel-room fields
+
+The hotel-room Product adds fields that are useful when comparing rooms:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `roomName` | string | Local or alternate room name |
+| `useableArea` | string | Display value for room area |
+| `capacity` | string | Guest capacity as published by the provider |
+| `floor` | string | Floor or floor range |
+| `bedType` | string | Bed configuration |
+| `windowType` | string | Window configuration |
+| `pricePerDay` | array | Daily prices covered by the offer |
+| `stockPerDay` | array | Daily inventory covered by the offer |
+| `instantConfirmation` | boolean | Whether the booking can be confirmed immediately |
+| `containedInPlace` | object | Hotel or property containing the room |
+| `smokingAllowed` | boolean | Whether smoking is permitted |
+| `petsAllowed` | boolean | Whether pets are permitted |
+
+These fields are optional extensions. If an offer contains `pricePerDay` and
+`stockPerDay`, both arrays should cover the same ordered set of dates defined
+by the interface request or surrounding response.
 
 ## Adding a Domain-Specific Field
 
 Before adding a field:
 
-1. Check whether the Agent Description specification already defines it.
-2. Check whether the declared external vocabulary contains a term with the
-   intended meaning.
-3. If neither does, declare or reuse a suitable prefix and use it consistently.
-4. State the expected JSON type and whether the field is optional or required
-   within the extension.
-5. Add a small example and update the interface contract if the field is used
-   as an input or output.
+1. Check whether ANP-07 already defines the field.
+2. Check whether the public definition selected for the product or service
+   already supplies a suitable name and value shape.
+3. Use a concise field name whose meaning does not conflict with an existing
+   field.
+4. Document the JSON type and whether the extension is optional or required.
+5. Add a representative example and update the interface contract when the
+   field is accepted as input or returned as output.
 
-Extensions should remain optional unless a separate specification makes them
-mandatory. A consumer that does not understand an optional extension should
-still be able to read the agent's identity, description, security settings, and
-interface links.
+Domain extensions should remain optional unless a separate specification
+makes them mandatory. A consumer that does not use an extension should still
+be able to read the agent's identity, security configuration, information
+links, and interfaces.
 
 ## Related Examples
 
 - [Hotel Agent Description](../examples/adp/hotel/examples/ad.json)
-- [Hotel room description](../examples/adp/hotel/examples/hotel_room.json)
-- [Coffee shop Agent Description](../examples/adp/lkcoffe/ad.json)
+- [Hotel room Product document](../examples/adp/hotel/examples/hotel_room.json)
+- [Hotel search interface](../examples/adp/hotel/examples/api/search-interface.yaml)
+- [Coffee-shop Agent Description](../examples/adp/lkcoffe/ad.json)
+- [Coffee Product document](../examples/adp/lkcoffe/silk-latte/silk-latte.json)
 - [Coffee purchase interface](../examples/adp/lkcoffe/api/purchase-interface.yaml)
 
 ## Copyright Notice

--- a/examples/adp/hotel/examples/ad.json
+++ b/examples/adp/hotel/examples/ad.json
@@ -1,37 +1,33 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "did": "https://w3id.org/did#",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "ad:AgentDescription",
-  "@id": "https://service.agent-network-protocol.com/agents/sheraton-chuzhou-hotel/ad.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "AgentDescription",
+  "url": "https://service.agent-network-protocol.com/agents/sheraton-chuzhou-hotel/ad.json",
   "name": "Hotel Booking Agent",
   "did": "did:wba:service.agent-network-protocol.com:wba:hotel",
   "owner": {
-    "@type": "Organization",
+    "type": "Organization",
     "name": "Hotel Chain Group",
-    "@id": "https://example-hotel-group.com"
+    "url": "https://example-hotel-group.com"
   },
   "description": "An intelligent hotel booking agent providing comprehensive hotel information, room availability, and booking services.",
-  "version": "1.0.0",
   "created": "2025-01-29T09:08:44Z",
-  "ad:securityDefinitions": {
+  "securityDefinitions": {
     "didwba_sc": {
       "scheme": "didwba",
       "in": "header",
       "name": "Authorization"
     }
   },
-  "ad:security": "didwba_sc",
-  "ad:domainEntity": {
-    "@type": "Hotel",
+  "security": "didwba_sc",
+  "domainEntity": {
+    "type": "Hotel",
     "hotelID": 372505161,
     "name": "滁州港汇喜来登酒店",
     "description": "滁州港汇喜来登酒店是喜达屋酒店及度假村国际集团旗下的喜来登品牌在滁州市的一家酒店。酒店位于滁州政治、商业和文化中心，毗邻滁州市政府，距离滁州高铁站仅5公里，距离南京也仅40分钟车程。",
-    "@id": "https://service.agent-network-protocol.com/agents/hotel/sheraton-chuzhou-hotel/hotel.json",
+    "url": "https://service.agent-network-protocol.com/agents/hotel/sheraton-chuzhou-hotel/hotel.json",
     "address": {
-      "@type": "PostalAddress",
+      "type": "PostalAddress",
       "streetAddress": "中都大道1599号",
       "addressLocality": "滁州",
       "addressRegion": "安徽省",
@@ -40,31 +36,31 @@
     "telephone": "0550-2201888",
     "openingDate": "2015",
     "starRating": {
-      "@type": "Rating",
+      "type": "Rating",
       "ratingValue": 5,
       "alternateName": "豪华型",
       "isRelatedTo": true
     },
     "geo": {
-      "@type": "GeoCoordinates",
+      "type": "GeoCoordinates",
       "latitude": 32.242098,
       "longitude": 118.332009
     },
     "image": [
       {
-        "@type": "ImageObject",
+        "type": "ImageObject",
         "url": "http://m.tuniucdn.com/fb3/s1/2n9c/Y3cwy3rmCHMeDe7U1ZKfaeFcNuk.jpg",
         "caption": "滁州港汇喜来登酒店 - 行政套房",
         "description": "豪华行政套房配备高档家具和设施，为商务和休闲旅客提供舒适优雅的住宿体验"
       },
       {
-        "@type": "ImageObject",
+        "type": "ImageObject",
         "url": "http://m.tuniucdn.com/fb3/s1/2n9c/6oebPwjLLWWmPt2dVRBPcKXEpVb.jpg",
         "caption": "滁州港汇喜来登酒店 - 豪华客房",
         "description": "宽敞明亮的豪华客房，配备现代化设施，为宾客提供舒适的入住体验"
       },
       {
-        "@type": "ImageObject",
+        "type": "ImageObject",
         "url": "http://m.tuniucdn.com/fb3/s1/2n9c/3dYduEb8VMQzTfaaJiDA3S4kyt5y.jpg",
         "caption": "滁州港汇喜来登酒店 - 行政酒廊",
         "description": "位于酒店高层的行政酒廊，为行政楼层客人提供专属休息和商务空间"
@@ -72,83 +68,94 @@
     ],
     "amenityFeature": [
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "残疾人客房",
         "value": true
       },
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "大堂吧",
         "value": true
       },
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "行政楼层",
         "value": true
       },
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "健身室",
         "value": true
       },
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "自动取款机",
         "value": true
       },
       {
-        "@type": "LocationFeatureSpecification",
+        "type": "LocationFeatureSpecification",
         "name": "餐厅",
         "value": true
       }
     ],
     "makesOffer": [
       {
-        "@type": "Offer",
+        "type": "Offer",
         "itemOffered": {
-          "@type": "Service",
+          "type": "Service",
           "name": "24小时前台服务"
         }
       },
       {
-        "@type": "Offer",
+        "type": "Offer",
         "itemOffered": {
-          "@type": "Service",
+          "type": "Service",
           "name": "商务服务"
         }
       },
       {
-        "@type": "Offer",
+        "type": "Offer",
         "itemOffered": {
-          "@type": "Service",
+          "type": "Service",
           "name": "邮政服务"
         }
       },
       {
-        "@type": "Offer",
+        "type": "Offer",
         "itemOffered": {
-          "@type": "Service",
+          "type": "Service",
           "name": "快速办理入住/退房手续"
         }
       }
     ]
   },
-  "ad:interfaces": [
+  "Infomations": [
     {
-      "@type": "ad:SearchInterface",
+      "type": "Product",
+      "description": "Hotel room details, rates, availability, and booking conditions.",
+      "url": "https://service.agent-network-protocol.com/agents/hotel/examples/hotel_room.json"
+    }
+  ],
+  "interfaces": [
+    {
+      "type": "StructuredInterface",
       "protocol": "YAML",
+      "version": "1.0.0",
       "url": "https://service.agent-network-protocol.com/agents/sheraton-chuzhou-hotel/api/search-interface.yaml",
       "description": "A YAML file for searching and filtering hotel information, such as room information, price information, etc."
     },
     {
-      "@type": "ad:BookingInterface",
+      "type": "StructuredInterface",
       "protocol": "YAML",
+      "version": "1.0",
+      "humanAuthorization": true,
       "url": "https://service.agent-network-protocol.com/agents/sheraton-chuzhou-hotel/api/booking-interface.yaml",
       "description": "A YAML file for hotel room booking and reservation management."
     },
     {
-      "@type": "ad:NaturalLanguageInterface",
+      "type": "NaturalLanguageInterface",
       "protocol": "YAML",
+      "version": "1.0",
       "url": "https://service.agent-network-protocol.com/agents/sheraton-chuzhou-hotel/api/nl-interface.yaml",
       "description": "A YAML file for interacting with the intelligent agent through natural language."
     }

--- a/examples/adp/hotel/examples/api/nl-interface.yaml
+++ b/examples/adp/hotel/examples/api/nl-interface.yaml
@@ -7,7 +7,7 @@ interface:
     - name: "askQuestion"
       description: "使用自然语言提问并获取自然语言回答，支持SSE返回。"
       method: "POST"
-      path: "/agents/lkcoffe/api/ask"
+      path: "/agents/hotel/api/ask"
       parameters:
         - name: "question"
           type: "string"

--- a/examples/adp/hotel/examples/api/search-interface.yaml
+++ b/examples/adp/hotel/examples/api/search-interface.yaml
@@ -2,13 +2,23 @@ openapi: 3.0.0
 info:
   title: Hotel Room Search Interface
   version: "1.0.0"
+  license:
+    name: MIT
+    url: https://github.com/agent-network-protocol/AgentNetworkProtocol/blob/main/LICENSE
   description: |
     This API allows searching for available hotel rooms based on check-in and check-out dates.
-    The response can either contain a URL to a JSON-LD file or the JSON-LD data directly.
+    The response can contain a URL to an ANP Product document or the product data directly.
+
+servers:
+  - url: https://service.agent-network-protocol.com
+
+security:
+  - didwba_sc: []
 
 paths:
   /agents/hotel/api/search:
     post:
+      operationId: searchHotelRooms
       summary: Search available hotel rooms
       requestBody:
         required: true
@@ -30,41 +40,46 @@ paths:
                 - checkOutDate
       responses:
         '200':
-          description: A successful response containing either a URL to hotel room details in JSON-LD format or the JSON-LD data itself.
+          description: A successful response containing either a URL to hotel room details or the product data itself.
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  jsonldUrls:
+                  urls:
                     type: array
-                    description: URLs to the JSON-LD files containing HotelRoom data as defined by schema.org
+                    description: URLs to ANP Product documents containing hotel room data
                     items:
                       type: string
                       format: uri
-                  jsonldData:
+                  data:
                     type: array
-                    description: JSON-LD formatted hotel room data
+                    description: Hotel room data using the ANP Product document format
                     items:
                       $ref: '#/components/schemas/HotelRoom'
-                required:
-                  - jsonldUrls
+        '400':
+          description: The check-in or check-out date is missing or invalid.
 components:
+  securitySchemes:
+    didwba_sc:
+      type: http
+      scheme: didwba
+      description: DID-WBA authentication using the Authorization header.
   schemas:
     HotelRoom:
       type: object
-      description: JSON-LD formatted hotel room data following schema.org's HotelRoom specification.
+      description: Hotel room data using the ANP Product document format.
       properties:
-        "@context":
-          type: object
-          description: JSON-LD context defining vocabulary.
-          example:
-            "@vocab": "https://schema.org/"
-            "ad": "https://service.agent-network-protocol.com/ad#"
-        "@type":
+        protocolType:
           type: string
-          example: "HotelRoom"
-        "@id":
+          example: "ANP"
+        protocolVersion:
+          type: string
+          example: "1.0.0"
+        type:
+          type: string
+          example: "Product"
+        url:
           type: string
           format: uri
           example: "https://service.agent-network-protocol.com/agents/hotel/examples/hotel_room.json"
@@ -100,7 +115,7 @@ components:
           items:
             type: object
             properties:
-              "@type":
+              type:
                 type: string
                 example: "ImageObject"
               url:
@@ -113,12 +128,12 @@ components:
               description:
                 type: string
                 example: "Luxurious room featuring floor-to-ceiling windows with panoramic ocean views"
-        facilities:
+        amenityFeature:
           type: array
           items:
             type: object
             properties:
-              "@type":
+              type:
                 type: string
                 example: "LocationFeatureSpecification"
               name:
@@ -128,58 +143,57 @@ components:
                 type: boolean
                 example: true
         offers:
-          type: array
-          items:
-            type: object
-            properties:
-              "@type":
-                type: string
-                example: "Offer"
-              identifier:
-                type: string
-                example: "RP20250204001"
-              name:
-                type: string
-                example: "标准价"
-              priceSpecification:
-                type: object
-                properties:
-                  "@type":
-                    type: string
-                    example: "UnitPriceSpecification"
-                  price:
-                    type: number
-                    format: float
-                    example: 1280.00
-                  priceCurrency:
-                    type: string
-                    example: "CNY"
-                  unitCode:
-                    type: string
-                    example: "DAY"
-                  priceType:
-                    type: string
-                    example: "https://schema.org/InvoicePrice"
-                  valueAddedTaxIncluded:
-                    type: boolean
-                    example: true
-              priceValidUntil:
-                type: string
-                format: date
-                example: "2025-12-31"
-              seller:
-                type: object
-                properties:
-                  "@type":
-                    type: string
-                    example: "Hotel"
-                  name:
-                    type: string
-                    example: "Sheraton Chuzhou Hotel"
+          type: object
+          properties:
+            type:
+              type: string
+              example: "Offer"
+            identifier:
+              type: string
+              example: "RP20250204001"
+            name:
+              type: string
+              example: "标准价"
+            priceSpecification:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: "UnitPriceSpecification"
+                price:
+                  type: number
+                  format: float
+                  example: 1280.00
+                priceCurrency:
+                  type: string
+                  example: "CNY"
+                unitCode:
+                  type: string
+                  example: "DAY"
+                priceType:
+                  type: string
+                  example: "https://schema.org/InvoicePrice"
+                valueAddedTaxIncluded:
+                  type: boolean
+                  example: true
+            priceValidUntil:
+              type: string
+              format: date
+              example: "2025-12-31"
+            seller:
+              type: object
+              properties:
+                type:
+                  type: string
+                  example: "Hotel"
+                name:
+                  type: string
+                  example: "Sheraton Chuzhou Hotel"
       required:
-        - "@context"
-        - "@type"
-        - "@id"
+        - protocolType
+        - protocolVersion
+        - type
+        - url
         - identifier
         - name
         - description

--- a/examples/adp/hotel/examples/api/search-interface.yaml
+++ b/examples/adp/hotel/examples/api/search-interface.yaml
@@ -3,7 +3,7 @@ info:
   title: Hotel Room Search Interface
   version: "1.0.0"
   license:
-    name: MIT
+    name: Apache-2.0
     url: https://github.com/agent-network-protocol/AgentNetworkProtocol/blob/main/LICENSE
   description: |
     This API allows searching for available hotel rooms based on check-in and check-out dates.
@@ -57,6 +57,11 @@ paths:
                     description: Hotel room data using the ANP Product document format
                     items:
                       $ref: '#/components/schemas/HotelRoom'
+                anyOf:
+                  - required:
+                      - urls
+                  - required:
+                      - data
         '400':
           description: The check-in or check-out date is missing or invalid.
 components:
@@ -140,8 +145,11 @@ components:
                 type: string
                 example: "空调"
               value:
-                type: boolean
-                example: true
+                oneOf:
+                  - type: boolean
+                  - type: string
+                  - type: number
+                example: "45 square meters"
         offers:
           type: object
           properties:

--- a/examples/adp/hotel/examples/hotel_room.json
+++ b/examples/adp/hotel/examples/hotel_room.json
@@ -1,14 +1,13 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "HotelRoom",
-  "@id": "https://service.agent-network-protocol.com/agents/hotel/examples/hotel_room.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "Product",
+  "url": "https://service.agent-network-protocol.com/agents/hotel/examples/hotel_room.json",
   "identifier": "room-deluxe-001",
   "roomName": "豪华海景房",
   "name": "Deluxe Ocean View Room",
   "description": "Spacious deluxe room with breathtaking ocean views, featuring modern amenities and elegant design.",
+  "category": "Hotel Room",
   "useableArea": "45 square meters",
   "capacity": "3",
   "floor": "15-20",
@@ -16,144 +15,83 @@
   "windowType": "Floor-to-ceiling windows",
   "image": [
     {
-      "@type": "ImageObject",
+      "type": "ImageObject",
       "url": "https://service.agent-network-protocol.com/agents/hotel/examples/deluxe-room-1.jpg",
       "caption": "豪华海景房 - 全景",
       "description": "Luxurious room featuring floor-to-ceiling windows with panoramic ocean views"
     },
     {
-      "@type": "ImageObject",
+      "type": "ImageObject",
       "url": "https://service.agent-network-protocol.com/agents/hotel/examples/deluxe-room-2.jpg",
       "caption": "豪华海景房 - 卧室",
       "description": "Bedroom with king-size bed and premium bedding"
     }
   ],
-  "facilities": [
-    {
-      "@type": "LocationFeatureSpecification",
-      "name": "空调",
-      "value": true
+  "offers": {
+    "type": "Offer",
+    "identifier": "RP20250204001",
+    "name": "标准价",
+    "priceSpecification": {
+      "type": "UnitPriceSpecification",
+      "price": 1280.00,
+      "priceCurrency": "CNY",
+      "unitCode": "DAY",
+      "priceType": "https://schema.org/InvoicePrice",
+      "valueAddedTaxIncluded": true
     },
-    {
-      "@type": "LocationFeatureSpecification",
-      "name": "独立卫浴",
-      "value": true
+    "pricePerDay": [1280, 1280, 1280],
+    "stockPerDay": [5, 4, 3],
+    "paymentMethod": {
+      "type": "PaymentMethod",
+      "name": "Prepayment required"
     },
-    {
-      "@type": "LocationFeatureSpecification",
-      "name": "Mini吧",
-      "value": true
-    }
-  ],
-  "offers": [
-    {
-      "@type": "Offer",
-      "identifier": "RP20250204001",
-      "name": "标准价",
-      "priceSpecification": {
-        "@type": "UnitPriceSpecification",
-        "price": 1280.00,
-        "priceCurrency": "CNY",
-        "unitCode": "DAY",
-        "priceType": "https://schema.org/InvoicePrice",
-        "valueAddedTaxIncluded": true
-      },
-      "pricePerDay": [1280, 1280, 1280],
-      "stockPerDay": [5, 4, 3],
-      "paymentMethod": {
-        "@type": "PaymentMethod",
-        "name": "Prepayment required"
-      },
-      "instantConfirmation": true,
-      "addOn": {
-        "@type": "Offer",
-        "name": "Breakfast",
-        "description": "含2份免费早餐"
-      },
-      "priceValidUntil": "2025-12-31",
-      "eligibleCustomerType": "https://schema.org/Individual",
-      "availability": "https://schema.org/InStock",
-      "businessFunction": "http://purl.org/goodrelations/v1#LeaseOut",
-      "seller": {
-        "@type": "Hotel",
-        "name": "Sheraton Chuzhou Hotel"
-      },
-      "termsOfService": {
-        "@type": "TermsOfService",
-        "name": "限时取消",
-        "cancelationPolicy": {
-          "@type": "CancellationPolicy",
-          "refundType": "Full refund",
-          "description": "入住日18:00前可免费取消",
-          "validUntil": "2025-02-04T18:00:00Z"
-        }
-      }
+    "instantConfirmation": true,
+    "addOn": {
+      "type": "Offer",
+      "name": "Breakfast",
+      "description": "含2份免费早餐"
     },
-    {
-      "@type": "Offer",
-      "identifier": "RP20250204002",
-      "name": "无早价",
-      "priceSpecification": {
-        "@type": "UnitPriceSpecification",
-        "price": 1180.00,
-        "priceCurrency": "CNY",
-        "unitCode": "DAY",
-        "priceType": "https://schema.org/InvoicePrice",
-        "valueAddedTaxIncluded": true
-      },
-      "pricePerDay": [1180, 1180, 1180],
-      "stockPerDay": [5, 4, 3],
-      "paymentMethod": {
-        "@type": "PaymentMethod",
-        "name": "Prepayment required"
-      },
-      "instantConfirmation": true,
-      "addOn": {
-        "@type": "Offer",
-        "name": "Breakfast",
-        "description": "不含早餐"
-      },
-      "priceValidUntil": "2025-12-31",
-      "eligibleCustomerType": "https://schema.org/Individual",
-      "availability": "https://schema.org/InStock",
-      "businessFunction": "http://purl.org/goodrelations/v1#LeaseOut",
-      "seller": {
-        "@type": "Hotel",
-        "name": "Sheraton Chuzhou Hotel"
-      },
-      "termsOfService": {
-        "@type": "TermsOfService",
-        "name": "不可取消",
-        "cancelationPolicy": {
-          "@type": "CancellationPolicy",
-          "refundType": "No refund",
-          "description": "预订成功后不可变更或取消"
-        }
+    "priceValidUntil": "2025-12-31",
+    "eligibleCustomerType": "https://schema.org/Individual",
+    "availability": "https://schema.org/InStock",
+    "businessFunction": "http://purl.org/goodrelations/v1#LeaseOut",
+    "seller": {
+      "type": "Hotel",
+      "name": "Sheraton Chuzhou Hotel"
+    },
+    "termsOfService": {
+      "type": "TermsOfService",
+      "name": "限时取消",
+      "cancelationPolicy": {
+        "type": "CancellationPolicy",
+        "refundType": "Full refund",
+        "description": "入住日18:00前可免费取消",
+        "validUntil": "2025-02-04T18:00:00Z"
       }
     }
-  ],
+  },
   "amenityFeature": [
     {
-      "@type": "LocationFeatureSpecification",
+      "type": "LocationFeatureSpecification",
       "name": "Room Size",
       "value": "45 square meters"
     },
     {
-      "@type": "LocationFeatureSpecification",
+      "type": "LocationFeatureSpecification",
       "name": "View",
       "value": "Ocean View"
     },
     {
-      "@type": "LocationFeatureSpecification",
+      "type": "LocationFeatureSpecification",
       "name": "Bathroom",
       "value": "En-suite bathroom with separate shower and bathtub"
     }
   ],
   "containedInPlace": {
-    "@type": "Hotel",
+    "type": "Hotel",
     "name": "Sheraton Chuzhou Hotel",
     "address": {
-      "@type": "PostalAddress",
+      "type": "PostalAddress",
       "streetAddress": "No. 299 Qingliu North Road",
       "addressLocality": "Chuzhou",
       "addressRegion": "Anhui",

--- a/examples/adp/lkcoffe/ad.json
+++ b/examples/adp/lkcoffe/ad.json
@@ -1,34 +1,30 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "did": "https://w3id.org/did#",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "ad:AgentDescription",
-  "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/ad.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "AgentDescription",
+  "url": "https://service.agent-network-protocol.com/agents/lkcoffe/ad.json",
   "name": "Luckin Coffee Agent",
   "did": "did:wba:service.agent-network-protocol.com:wba:lkcoffe",
   "owner": {
-    "@type": "Organization",
+    "type": "Organization",
     "name": "Luckin Coffee",
-    "@id": "https://luckincoffee.com"
+    "url": "https://luckincoffee.com"
   },
   "description": "Luckin Coffee's intelligent agent providing product information and customization options.",
-  "version": "1.0.0",
   "created": "2025-01-03T10:56:57Z",
-  "ad:securityDefinitions": {
+  "securityDefinitions": {
     "didwba_sc": {
       "scheme": "didwba",
       "in": "header",
       "name": "Authorization"
     }
   },
-  "ad:security": "didwba_sc",
-  "ad:domainEntity": {
-    "@type": "CafeOrCoffeeShop",
+  "security": "didwba_sc",
+  "domainEntity": {
+    "type": "CafeOrCoffeeShop",
     "name": "Luckin Coffee",
     "address": {
-      "@type": "PostalAddress",
+      "type": "PostalAddress",
       "streetAddress": "XX Road No.XX",
       "addressLocality": "Some City",
       "addressRegion": "Some Province",
@@ -36,44 +32,47 @@
       "addressCountry": "CN"
     },
     "telephone": "+86-10-12345678",
-    "url": "https://www.starbucks.com",
+    "url": "https://luckincoffee.com",
     "openingHours": "Mo-Su 07:00-22:00",
     "geo": {
-      "@type": "GeoCoordinates",
+      "type": "GeoCoordinates",
       "latitude": 39.9042,
       "longitude": 116.4074
-    },
-    "ad:products": [
+    }
+  },
+  "Infomations": [
       {
-        "@type": "Product",
+        "type": "Product",
         "name": "Silk Latte",
         "description": "Made with high-quality milk source, providing a silky smooth taste, suitable for consumers pursuing health and taste.",
-        "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/silk-latte.json"
+        "url": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/silk-latte.json"
       },
       {
-        "@type": "Product",
+        "type": "Product",
         "name": "Orange C Americano",
         "description": "Niche fruit aroma paired with rich coffee, suitable for consumers seeking freshness and unique flavors.",
-        "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/orange-americano.json"
+        "url": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/orange-americano.json"
       },
       {
-        "@type": "Product",
+        "type": "Product",
         "name": "Roasted Coconut Latte",
         "description": "Roasted at around 135°C, featuring unique coconut sugar flavor, perfect for winter consumption. This beverage combines coconut juice and roasted coconut bits, offering a healthy choice with five 'zero' features, using master-crafted Espresso from IIAC gold medal coffee beans.",
-        "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json"
+        "url": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json"
       }
-    ]
-  },
-  "ad:interfaces": [
+  ],
+  "interfaces": [
     {
-      "@type": "ad:NaturalLanguageInterface",
+      "type": "NaturalLanguageInterface",
       "protocol": "YAML",
+      "version": "1.0",
       "url": "https://service.agent-network-protocol.com/agents/lkcoffe/api/nl-interface.yaml",
       "description": "A YAML file for interacting with the intelligent agent through natural language."
     },
     {
-      "@type": "ad:PurchaseInterface",
+      "type": "StructuredInterface",
       "protocol": "YAML",
+      "version": "1.0",
+      "humanAuthorization": true,
       "url": "https://service.agent-network-protocol.com/agents/lkcoffe/api/purchase-interface.yaml",
       "description": "A YAML file for interacting with the intelligent agent through purchase."
     }

--- a/examples/adp/lkcoffe/orange-americano/orange-americano.json
+++ b/examples/adp/lkcoffe/orange-americano/orange-americano.json
@@ -1,98 +1,98 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "Product",
-  "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/orange-americano.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "Product",
+  "url": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/orange-americano.json",
   "identifier": "oa-29ab8cf9",
   "name": "橙C美式",
   "description": "小众果香，搭配浓郁咖啡，适合追求新鲜感和独特口味的消费者。",
   "brand": {
-    "@type": "Brand",
+    "type": "Brand",
     "name": "瑞幸咖啡"
   },
   "additionalProperty": [
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Feature",
       "value": "大师级Espresso，使用IIAC金奖咖啡豆"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Slogan",
       "value": "橙C美式 破亿杯！"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Juice Content",
       "value": "1杯橙汁含量 ≈ 1个橙子"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Flavor",
       "value": "浓郁橙香，清新沁爽"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Coffee Blend",
       "value": "定制融合IIAC金奖浓缩咖啡，口感丰富高亮亮味蕾"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Espresso",
       "value": "大师级定制Espresso，源自IIAC金奖咖啡豆"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Coffee Origin",
       "value": "瑞幸冠军团队经历上百次调试，寻求多产区咖啡豆专业拼配方案，甄选100%阿拉比卡咖啡豆，捕捉埃塞俄比亚、巴西、哥伦比亚、危地马拉等产区风味特征，呈现独特风味与浓醇口感"
     }
   ],
   "offers": {
-    "@type": "Offer",
+    "type": "Offer",
     "price": "20",
     "priceCurrency": "CNY",
     "availability": "https://schema.org/InStock"
   },
-  "image": {
-    "@type": "ImageObject",
-    "url": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/instruction.jpg",
-    "caption": "橙C美式 - 小众果香与浓郁咖啡的完美融合",
-    "description": "一杯清新橙香与浓郁咖啡完美融合的饮品，使用IIAC金奖咖啡豆制作，搭配新鲜橙汁，呈现独特的果香咖啡体验"
-  },
+  "image": [
+    {
+      "type": "ImageObject",
+      "url": "https://service.agent-network-protocol.com/agents/lkcoffe/orange-americano/instruction.jpg",
+      "caption": "橙C美式 - 小众果香与浓郁咖啡的完美融合",
+      "description": "一杯清新橙香与浓郁咖啡完美融合的饮品，使用IIAC金奖咖啡豆制作，搭配新鲜橙汁，呈现独特的果香咖啡体验"
+    }
+  ],
   "audience": {
-    "@type": "Audience",
+    "type": "Audience",
     "audienceType": "咖啡爱好者"
   },
   "manufacturer": {
-    "@type": "Organization",
+    "type": "Organization",
     "name": "瑞幸咖啡",
     "url": "https://luckincoffee.com"
   },
   "customizationOptions": {
-    "@type": "ad:CustomizationOptions",
+    "type": "CustomizationOptions",
     "options": [
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "杯型",
         "isRequired": true,
         "value": ["小杯", "中杯", "大杯"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "咖啡豆",
         "isRequired": true,
         "value": ["IIAC金奖豆"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "温度",
         "isRequired": true,
         "value": ["冰", "热"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "糖度",
         "isRequired": true,
         "value": ["标准甜", "少甜", "少少甜", "微甜", "不另外加糖"]

--- a/examples/adp/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json
+++ b/examples/adp/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json
@@ -1,42 +1,40 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "Product",
-  "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "Product",
+  "url": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/roasted-coconut-latte.json",
   "identifier": "rl-29ab8cf9",
   "name": "烤椰拿铁",
   "description": "135°C左右高温烘烤，独特椰子糖味道，适合冬季饮用。这款饮品结合了椰肉汁和烤椰粒，提供五个‘0’轻轻享的健康选择，使用大师级定制的Espresso，源自IIAC金奖咖啡豆。",
   "brand": {
-    "@type": "Brand",
+    "type": "Brand",
     "name": "瑞幸咖啡"
   },
   "additionalProperty": [
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Feature",
       "value": "椰肉汁 & 烤椰粒调配, 5个‘0’轻轻享（0乳糖、0植脂末、0蔗糖固体、0反式脂肪酸、0香精物加）, 大师级定制Espresso，源自IIAC金奖咖啡豆"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Slogan",
       "value": "冬季特饮 暖暖回归"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Additional Info",
       "value": "记忆中的椰子椰味道"
     }
   ],
   "offers": {
-    "@type": "Offer",
+    "type": "Offer",
     "price": "13",
     "priceCurrency": "CNY",
     "availability": "https://schema.org/InStock"
   },
   "nutrition": {
-    "@type": "NutritionInformation",
+    "type": "NutritionInformation",
     "calories": "150",
     "fatContent": "0g",
     "sugarContent": "0g",
@@ -47,33 +45,35 @@
   "ingredients": "椰奶，浓缩咖啡，烤椰糖浆",
   "category": "饮料",
   "sku": "LK-COCONUT-LATTE",
-  "image": {
-    "@type": "ImageObject",
-    "url": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/instruction.jpeg",
-    "caption": "烤椰拿铁 - 冬季特饮暖暖回归",
-    "description": "采用135°C高温烘烤工艺，完美融合椰肉汁和烤椰粒，搭配IIAC金奖咖啡豆制作的Espresso，带来独特的烤椰香与咖啡香的完美融合"
-  },
+  "image": [
+    {
+      "type": "ImageObject",
+      "url": "https://service.agent-network-protocol.com/agents/lkcoffe/roasted-coconut-latte/instruction.jpeg",
+      "caption": "烤椰拿铁 - 冬季特饮暖暖回归",
+      "description": "采用135°C高温烘烤工艺，完美融合椰肉汁和烤椰粒，搭配IIAC金奖咖啡豆制作的Espresso，带来独特的烤椰香与咖啡香的完美融合"
+    }
+  ],
   "audience": {
-    "@type": "Audience",
+    "type": "Audience",
     "audienceType": "咖啡爱好者",
     "geographicArea": "中国"
   },
   "manufacturer": {
-    "@type": "Organization",
+    "type": "Organization",
     "name": "瑞幸咖啡",
     "url": "https://luckincoffee.com"
   },
   "customizationOptions": {
-    "@type": "ad:CustomizationOptions",
+    "type": "CustomizationOptions",
     "options": [
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "温度",
         "isRequired": true,
         "value": ["冰", "热"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "糖度",
         "isRequired": true,
         "value": ["标准甜", "少甜", "微甜", "不另外加糖"]

--- a/examples/adp/lkcoffe/silk-latte/silk-latte.json
+++ b/examples/adp/lkcoffe/silk-latte/silk-latte.json
@@ -1,73 +1,73 @@
 {
-  "@context": {
-    "@vocab": "https://schema.org/",
-    "ad": "https://service.agent-network-protocol.com/ad#"
-  },
-  "@type": "Product",
-  "@id": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/silk-latte.json",
+  "protocolType": "ANP",
+  "protocolVersion": "1.0.0",
+  "type": "Product",
+  "url": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/silk-latte.json",
   "identifier": "sl-29ab8cf9",
   "name": "丝绸拿铁",
   "description": "采用高品质奶源，提供丝滑口感，适合追求健康和口感的消费者。",
   "brand": {
-    "@type": "Brand",
+    "type": "Brand",
     "name": "瑞幸咖啡"
   },
   "additionalProperty": [
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Feature",
       "value": "丝滑厚奶，丝滑蛋白含量 20.99%, 0乳糖、0植脂末、0蔗糖固体、0反式脂肪酸、0香精物加"
     },
     {
-      "@type": "PropertyValue",
+      "type": "PropertyValue",
       "name": "Slogan",
       "value": "添加丝绸风味厚奶"
     }
   ],
   "offers": {
-    "@type": "Offer",
+    "type": "Offer",
     "price": "20",
     "priceCurrency": "CNY",
     "availability": "https://schema.org/InStock"
   },
-  "image": {
-    "@type": "ImageObject",
-    "url": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/instruction.jpg",
-    "caption": "丝绸拿铁 - 丝滑浓郁的咖啡体验",
-    "description": "采用高品质奶源制作的丝滑拿铁，0乳糖、0植脂末，带来纯净丝滑的口感体验，搭配优质咖啡豆，呈现完美平衡的咖啡风味"
-  },
+  "image": [
+    {
+      "type": "ImageObject",
+      "url": "https://service.agent-network-protocol.com/agents/lkcoffe/silk-latte/instruction.jpg",
+      "caption": "丝绸拿铁 - 丝滑浓郁的咖啡体验",
+      "description": "采用高品质奶源制作的丝滑拿铁，0乳糖、0植脂末，带来纯净丝滑的口感体验，搭配优质咖啡豆，呈现完美平衡的咖啡风味"
+    }
+  ],
   "audience": {
-    "@type": "Audience",
+    "type": "Audience",
     "audienceType": "咖啡爱好者"
   },
   "manufacturer": {
-    "@type": "Organization",
+    "type": "Organization",
     "name": "瑞幸咖啡",
     "url": "https://luckincoffee.com"
   },
   "customizationOptions": {
-    "@type": "ad:CustomizationOptions",
+    "type": "CustomizationOptions",
     "options": [
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "杯型",
         "isRequired": true,
         "value": ["小杯", "中杯", "大杯"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "咖啡豆",
         "isRequired": true,
         "value": ["IIAC金奖豆", "深烘拼配豆"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "温度",
         "isRequired": true,
         "value": ["冰", "热"]
       },
       {
-        "@type": "PropertyValue",
+        "type": "PropertyValue",
         "name": "糖度",
         "isRequired": true,
         "value": ["标准甜", "少甜", "少少甜", "微甜", "不另外加糖"]


### PR DESCRIPTION
### 🔗 Related Issue | 相关 Issue

Closes #16

---

### 📝 PR Type | PR 类型

- [ ] Feature | 新功能
- [ ] Bugfix | 问题修复
- [x] Documentation | 文档修改
- [ ] Style | 代码格式（不影响功能）
- [ ] Refactor | 重构
- [ ] Test | 测试相关
- [ ] Chore | 其他

---

### 📋 Description | 描述

Adds a non-normative guide for extended fields used by Agent Description and Product documents.

This PR also aligns the existing hotel and coffee-shop examples with the standard JSON format defined by ANP-07 v1.1.

Changes include:

- documenting the standard ANP-07 Agent Description fields;
- documenting optional `domainEntity`, `customizationOptions`, and hotel-room fields;
- migrating the hotel and coffee-shop examples from legacy JSON-LD to standard JSON;
- replacing JSON-LD keywords and `ad:`-prefixed fields;
- using `NaturalLanguageInterface` and `StructuredInterface` consistently;
- updating the hotel search interface to return standard ANP Product documents;
- removing the obsolete empty JSON-LD section heading from ANP-07.

Validation performed:

- Parsed all six updated JSON documents.
- Parsed all JSON snippets in the guide.
- Confirmed that documentation links resolve.
- Confirmed that no JSON-LD constructs remain under `examples/adp`.
- Validated the updated OpenAPI document with Redocly.
- Ran `git diff --check` successfully.

---

### ⚠️ Breaking Changes | 破坏性变更

- [ ] Yes
- [x] No

---

### ✅ Checklist | 检查项

- [ ] The code compiles correctly | 代码可以正确编译
- [ ] All tests passed | 所有测试均通过
- [x] Relevant documentation updated | 已更新相关文档
- [x] PR has been linked to the related issue | 已关联相关 Issue

Compilation and automated tests are not applicable because this is a documentation and example-data update.