### PR TITLE
fix: preserve avatars when contributor stats are pending

### DIFF
--- a/scripts/update_contributors.js
+++ b/scripts/update_contributors.js
@@ -82,8 +82,9 @@ async function fetchContributors({github, context, core, delay = setTimeout}) {
     }
   } else {
     core.warning(
-      `Contributor statistics unavailable; using the contributor list only (HTTP ${statsResponse?.status ?? 'unknown'})`,
+      `Contributor statistics unavailable; leaving READMEs unchanged (HTTP ${statsResponse?.status ?? 'unknown'})`,
     );
+    return null;
   }
 
   return Array.from(contributorsById.values()).sort((left, right) => {
@@ -121,8 +122,16 @@ function renderContributorBlock(source, avatars, file) {
   );
 }
 
-async function updateReadmes({github, context, core, fileSystem = fs}) {
-  const contributors = await fetchContributors({github, context, core});
+async function updateReadmes({
+  github,
+  context,
+  core,
+  fileSystem = fs,
+  delay = setTimeout,
+}) {
+  const contributors = await fetchContributors({github, context, core, delay});
+  if (contributors === null) return;
+
   const avatars = renderAvatars(contributors);
 
   for (const file of README_FILES) {

--- a/tests/update_contributors.test.js
+++ b/tests/update_contributors.test.js
@@ -61,7 +61,7 @@ test('fetchContributors merges statistics, excludes bots, and sorts deterministi
   assert.equal(requests.length, 2);
 });
 
-test('fetchContributors falls back when contributor statistics stay unavailable', async () => {
+test('fetchContributors skips updates when contributor statistics stay unavailable', async () => {
   const warnings = [];
   const github = {
     request: async (route) =>
@@ -77,9 +77,35 @@ test('fetchContributors falls back when contributor statistics stay unavailable'
     delay: (resolve) => resolve(),
   });
 
-  assert.equal(contributors.length, 1);
+  assert.equal(contributors, null);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /HTTP 202/);
+});
+
+test('updateReadmes leaves existing avatars unchanged when statistics are unavailable', async () => {
+  let writeCount = 0;
+
+  await updateReadmes({
+    github: {
+      request: async (route) =>
+        route.includes('/stats/')
+          ? {status: 202, data: {}}
+          : {status: 200, data: [author(1, 'alpha', 2)]},
+    },
+    context: {repo: {owner: 'owner', repo: 'repo'}},
+    core: {info: () => {}, warning: () => {}},
+    delay: (resolve) => resolve(),
+    fileSystem: {
+      readFileSync: () => {
+        throw new Error('README should not be read');
+      },
+      writeFileSync: () => {
+        writeCount += 1;
+      },
+    },
+  });
+
+  assert.equal(writeCount, 0);
 });
 
 test('renderContributorBlock replaces exactly one marked block', () => {


### PR DESCRIPTION
## Summary

- keep the existing README contributor blocks unchanged when GitHub's contributor statistics endpoint returns `202`
- prevent an incomplete contributor list from deleting valid historical avatars
- add focused regression coverage for the no-write behavior

## Root cause

The basic contributors endpoint and contributor statistics endpoint are not equivalent: the basic list can temporarily omit contributors that are still present in the statistics data. Falling back to the incomplete list therefore produced destructive README changes.

## Validation

- `node --test tests/update_contributors.test.js` — 5 tests passed
- `node --check scripts/update_contributors.js`
- `git diff --check`

The incomplete `automation/update-contributor-avatars` branch created by the failed run was deleted.